### PR TITLE
feat: update electron-click-drag-plugin to support macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build native addon (cross-platform)
 
 on:
   push:
-    branches: [ "github-actions" ]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
   release:
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 -> Intel x64, macos-14 -> Apple Silicon arm64
-        os: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, windows-latest, macos-14 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 -> Intel x64, macos-14 -> Apple Silicon arm64
-        os: [ ubuntu-latest, windows-latest, macos-14 ]
+        os: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,121 @@
+name: Build native addon (cross-platform)
+
+on:
+  push:
+    branches: [ "github-actions" ]
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-13 -> Intel x64, macos-14 -> Apple Silicon arm64
+        os: [ ubuntu-latest, windows-latest, macos-13, macos-14 ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Python (for node-gyp)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build deps (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3 make g++ libx11-dev
+
+      - name: Install dependencies (skip Electron download)
+        run: npm ci --ignore-scripts
+
+      - name: Build with node-gyp
+        run: npx node-gyp configure build
+
+      - name: Compute platform/arch
+        id: meta
+        shell: bash
+        run: |
+          PLATFORM=$(node -p "require('os').platform()")
+          ARCH=$(node -p "require('os').arch()")
+          echo "platform=$PLATFORM" >> $GITHUB_OUTPUT
+          echo "arch=$ARCH" >> $GITHUB_OUTPUT
+          echo "Building for $PLATFORM-$ARCH"
+
+      - name: Package prebuilt binary
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const os = require('os');
+          const platform = os.platform();
+          const arch = os.arch();
+          const src = path.join('build','Release','drag.node');
+          if (!fs.existsSync(src)) {
+            console.error('Build output not found:', src);
+            process.exit(1);
+          }
+          const dstDir = path.join('build','Release', `${platform}-${arch}`);
+          fs.mkdirSync(dstDir, { recursive: true });
+          const dst = path.join(dstDir, 'drag.node');
+          fs.copyFileSync(src, dst);
+          console.log('Packaged binary to', dst);
+          NODE
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: drag-${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}
+          path: build/Release/${{ steps.meta.outputs.platform }}-${{ steps.meta.outputs.arch }}/drag.node
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm (on release)
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: drag-*
+          merge-multiple: true
+          path: build/Release
+
+      - name: List downloaded files
+        run: |
+          echo "Downloaded prebuilt binaries:"
+          find build -type f -maxdepth 3 -print || true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Configure npm auth
+        if: ${{ env.NPM_TOKEN != '' }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
+      - name: Publish to npm
+        if: ${{ env.NPM_TOKEN != '' }}
+        run: npm publish --access public
+

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ app.whenReady().then(() => {
   ipcMain.on('start-drag', () => {
     try {
       const hwndBuffer = win.getNativeWindowHandle();
-      // On Linux, extract the window ID from the buffer (first 4 bytes, little-endian)
+      // Linux: extract X11 Window ID from the buffer (first 4 bytes, little-endian)
+      // macOS/Windows: pass Buffer directly
       const windowId = process.platform === 'linux'
-      ? hwndBuffer.readUInt32LE(0)
-      : hwndBuffer;
+        ? hwndBuffer.readUInt32LE(0)
+        : hwndBuffer;
 
       dragAddon.startDrag(windowId);
     } catch (error) {
@@ -56,7 +57,7 @@ app.whenReady().then(() => {
 });
 ```
 ### ✅ Tested On
-Windows 10 / 11, Linux (Fedora)
+Windows 10 / 11, Linux (Fedora), macOS (15.6 M1)
 
 Standard Electron (>= v22)
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,11 @@
   "targets": [
     {
       "target_name": "drag",
-      "sources": [ "drag.cc" ],
+      "sources": [
+        "drag_common.cc",
+        "drag_win.cc",
+        "drag_linux.cc"
+      ],
       "include_dirs": [
         "<!(node -p \"require('node-addon-api').include_dir\")",
         "<!(node -p \"require('node-addon-api').include\")"
@@ -12,6 +16,15 @@
       "conditions": [
         [ "OS=='win'", {
           "libraries": [ "user32.lib" ]
+        }],
+        [ "OS=='mac'", {
+          "sources": [ "drag_mac.mm" ],
+          "xcode_settings": {
+            "OTHER_CPLUSPLUSFLAGS": [ "-ObjC++" ]
+          },
+          "link_settings": {
+            "libraries": [ "-framework", "Cocoa" ]
+          }
         }]
       ]
     }

--- a/drag.h
+++ b/drag.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <napi.h>
+
+// Starts an OS-level window drag for the given native handle/identifier.
+// Windows: expects a Buffer containing HWND bytes from getNativeWindowHandle().
+// Linux (X11): expects a Number window id (from first 4 bytes of the Buffer).
+// macOS: expects a Buffer with NSWindow* from getNativeWindowHandle().
+Napi::Value StartDrag(const Napi::CallbackInfo& info);
+
+// Module initialization common to all platforms
+Napi::Object Init(Napi::Env env, Napi::Object exports);

--- a/drag_common.cc
+++ b/drag_common.cc
@@ -1,0 +1,8 @@
+#include "drag.h"
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("startDrag", Napi::Function::New(env, StartDrag));
+  return exports;
+}
+
+NODE_API_MODULE(drag, Init)

--- a/drag_linux.cc
+++ b/drag_linux.cc
@@ -1,0 +1,55 @@
+#include "drag.h"
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <unistd.h>
+
+Napi::Value StartDrag(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1) {
+    Napi::TypeError::New(env, "Expected window id as first argument").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Display* display = XOpenDisplay(NULL);
+  if (!display) {
+    Napi::TypeError::New(env, "Cannot open X display").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Window window = (Window)info[0].As<Napi::Number>().Int64Value();
+
+  Window root, child;
+  int root_x, root_y, win_x, win_y;
+  unsigned int mask;
+  XQueryPointer(display, window, &root, &child, &root_x, &root_y, &win_x, &win_y, &mask);
+
+  Atom moveAtom = XInternAtom(display, "_NET_WM_MOVERESIZE", False);
+  if (moveAtom == None) {
+    XCloseDisplay(display);
+    Napi::TypeError::New(env, "Cannot find _NET_WM_MOVERESIZE atom").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  XEvent xev = {0};
+  xev.xclient.type = ClientMessage;
+  xev.xclient.window = window;
+  xev.xclient.message_type = moveAtom;
+  xev.xclient.format = 32;
+  xev.xclient.data.l[0] = root_x;
+  xev.xclient.data.l[1] = root_y;
+  xev.xclient.data.l[2] = 8; // _NET_WM_MOVERESIZE_MOVE
+  xev.xclient.data.l[3] = 1; // button 1
+  xev.xclient.data.l[4] = 0;
+
+  XSendEvent(display, DefaultRootWindow(display), False,
+             SubstructureRedirectMask | SubstructureNotifyMask, &xev);
+
+  XFlush(display);
+  XCloseDisplay(display);
+
+  return env.Null();
+}
+#endif

--- a/drag_mac.mm
+++ b/drag_mac.mm
@@ -1,0 +1,74 @@
+#include "drag.h"
+
+#ifdef __APPLE__
+#import <Cocoa/Cocoa.h>
+
+// Electron's getNativeWindowHandle returns a Buffer containing the NSWindow*.
+// We can call -performWindowDragWithEvent: if we can synthesize/obtain an NSEvent.
+// Since we are invoked from a mousedown handler on the renderer side typically,
+// the actual NSEvent already occurred. We can trigger drag based on current mouse
+// position by creating a leftMouseDragged event and calling performWindowDragWithEvent.
+
+static NSEvent* CreateDragEvent(NSWindow* window) {
+  // Use window-local mouse location for the synthetic event
+  NSPoint local = [window mouseLocationOutsideOfEventStream];
+  NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+  NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                       location:local
+                                  modifierFlags:0
+                                      timestamp:now
+                                   windowNumber:window.windowNumber
+                                        context:nil
+                                    eventNumber:0
+                                     clickCount:1
+                                       pressure:1.0];
+  return event;
+}
+
+Napi::Value StartDrag(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsBuffer()) {
+    Napi::TypeError::New(env, "Expected buffer as first argument").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  auto buf = info[0].As<Napi::Buffer<char>>();
+  // NSWindow* is pointer-sized
+  if (buf.Length() < sizeof(void*)) {
+    Napi::TypeError::New(env, "Invalid native handle buffer").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  // Electron may return either NSWindow* or NSView* depending on version.
+  // Read as Objective-C id and resolve window accordingly.
+  id obj = *reinterpret_cast<id*>(buf.Data());
+  if (!obj) {
+    Napi::TypeError::New(env, "Null native pointer").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  NSWindow* window = nil;
+  if ([obj isKindOfClass:[NSWindow class]]) {
+    window = (NSWindow*)obj;
+  } else if ([obj isKindOfClass:[NSView class]]) {
+    window = [(NSView*)obj window];
+  }
+  if (!window) {
+    Napi::TypeError::New(env, "Could not resolve NSWindow from handle").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      if ([window respondsToSelector:@selector(performWindowDragWithEvent:)]) {
+        NSEvent* ev = CreateDragEvent(window);
+        [window performWindowDragWithEvent:ev];
+      } else {
+        // Fallback: begin a standard window drag via performDrag
+        // Not typically needed on modern macOS.
+      }
+    }
+  });
+
+  return env.Null();
+}
+#endif

--- a/drag_win.cc
+++ b/drag_win.cc
@@ -1,0 +1,38 @@
+#include "drag.h"
+
+#ifdef _WIN32
+#include <windows.h>
+
+Napi::Value StartDrag(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1 || !info[0].IsBuffer()) {
+    Napi::TypeError::New(env, "Expected buffer as first argument").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  HWND hwnd = *reinterpret_cast<HWND*>(info[0].As<Napi::Buffer<char>>().Data());
+
+  POINT startPos;
+  GetCursorPos(&startPos);
+  int startX = startPos.x;
+  int startY = startPos.y;
+
+  ScreenToClient(hwnd, &startPos);
+  LPARAM lParam = MAKELPARAM(startPos.x, startPos.y);
+
+  ReleaseCapture();
+  SendMessage(hwnd, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
+
+  POINT endPos;
+  GetCursorPos(&endPos);
+  int endX = endPos.x;
+  int endY = endPos.y;
+
+  if (endX == startX && endY == startY) {
+    SendMessage(hwnd, WM_LBUTTONUP, 0, lParam);
+  }
+
+  return env.Null();
+}
+#endif

--- a/index.js
+++ b/index.js
@@ -4,14 +4,20 @@ const os = require('os');
 const platform = os.platform();
 const arch = os.arch();
 
-let binaryPath;
+// Prefer prebuilt binaries when available; fallback to local build
+const prebuilt = {
+  'win32-x64': 'build/Release/win32-x64/drag.node',
+  'linux-x64': 'build/Release/linux-x64/drag.node',
+  'darwin-x64': 'build/Release/darwin-x64/drag.node',
+  'darwin-arm64': 'build/Release/darwin-arm64/drag.node',
+};
 
-if (platform === 'win32' && arch === 'x64') {
-  binaryPath = path.join(__dirname, 'build/Release/win32-x64/drag.node');
-} else if (platform === 'linux' && arch === 'x64') {
-  binaryPath = path.join(__dirname, 'build/Release/linux-x64/drag.node');
-} else {
-  throw new Error(`Unsupported platform: ${platform}-${arch}`);
+const key = `${platform}-${arch}`;
+let binaryPath = prebuilt[key] ? path.join(__dirname, prebuilt[key]) : null;
+
+try {
+  module.exports = require(binaryPath || path.join(__dirname, 'build/Release/drag.node'));
+} catch (e) {
+  // Fallback to generic build path if prebuilt missing
+  module.exports = require(path.join(__dirname, 'build/Release/drag.node'));
 }
-
-module.exports = require(binaryPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,15 @@
 {
   "name": "electron-click-drag-plugin",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
+      "name": "electron-click-drag-plugin",
+      "version": "2.0.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "devDependencies": {
         "electron": "^37.2.6",
         "node-addon-api": "^8.5.0"
       }
@@ -13,6 +18,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -34,6 +40,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -46,6 +53,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -58,6 +66,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -70,12 +79,14 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -85,6 +96,7 @@
       "version": "22.17.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
       "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -94,6 +106,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -103,6 +116,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -114,6 +128,7 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -121,6 +136,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -130,6 +146,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -139,6 +156,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -157,6 +175,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -169,6 +188,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -186,6 +206,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -201,6 +222,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -213,6 +235,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -222,6 +245,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -240,6 +264,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -258,6 +283,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -265,6 +291,7 @@
       "version": "37.2.6",
       "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
       "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -283,6 +310,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -292,6 +320,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -301,6 +330,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -311,6 +341,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -321,6 +352,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -328,6 +360,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -341,6 +374,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -361,6 +395,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -370,6 +405,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -384,6 +420,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -399,6 +436,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -417,6 +455,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -430,6 +469,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -447,6 +487,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -460,6 +501,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -485,12 +527,14 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -504,12 +548,14 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -523,12 +569,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -536,6 +584,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -545,6 +594,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -554,6 +604,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -563,6 +614,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -576,6 +628,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -585,12 +638,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
       "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -600,6 +655,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -612,6 +668,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -622,6 +679,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -631,6 +689,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -640,12 +699,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -655,6 +716,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -665,6 +727,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -677,12 +740,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -695,6 +760,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -713,6 +779,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -722,6 +789,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -729,6 +797,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -745,6 +814,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -752,6 +822,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
@@ -764,6 +835,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -777,12 +849,14 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -792,12 +866,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-click-drag-plugin",
-  "version": "2.0.1",
-  "description": "A native Electron plugin for click-and-drag functionality (Windows + Linux)",
+  "version": "2.0.2",
+  "description": "A native Electron plugin for click-and-drag functionality (Windows + Linux + macOS)",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "noobfromph",
@@ -16,12 +16,15 @@
     "drag",
     "windows",
     "linux",
+    "macos",
     "addon",
     "click-drag"
   ],
   "files": [
     "build/Release/win32-x64/drag.node",
     "build/Release/linux-x64/drag.node",
+    "build/Release/darwin-x64/drag.node",
+    "build/Release/darwin-arm64/drag.node",
     "index.js",
     "index.d.ts",
     "README.md",

--- a/test/main.js
+++ b/test/main.js
@@ -1,7 +1,7 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 
-// Load the compiled native addon
-const dragAddon = require('../build/Release/drag.node');
+// Load the addon via package entry (handles platform paths)
+const dragAddon = require('..');
 
 app.whenReady().then(() => {
   const win = new BrowserWindow({
@@ -20,11 +20,9 @@ app.whenReady().then(() => {
   win.webContents.openDevTools();
 
   ipcMain.on('start-drag', (event) => {
-    const hwndBuffer = win.getNativeWindowHandle();
-    // On Linux, extract the window ID from the buffer (first 4 bytes, little-endian)
-    const windowId = process.platform === 'linux'
-      ? hwndBuffer.readUInt32LE(0)
-      : hwndBuffer;
+  const hwndBuffer = win.getNativeWindowHandle();
+  // Linux: extract window id; macOS/Windows: pass the buffer
+  const windowId = process.platform === 'linux' ? hwndBuffer.readUInt32LE(0) : hwndBuffer;
     dragAddon.startDrag(windowId);
   });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -20,9 +20,9 @@ app.whenReady().then(() => {
   win.webContents.openDevTools();
 
   ipcMain.on('start-drag', (event) => {
-  const hwndBuffer = win.getNativeWindowHandle();
-  // Linux: extract window id; macOS/Windows: pass the buffer
-  const windowId = process.platform === 'linux' ? hwndBuffer.readUInt32LE(0) : hwndBuffer;
+    const hwndBuffer = win.getNativeWindowHandle();
+    // Linux: extract window id; macOS/Windows: pass the buffer
+    const windowId = process.platform === 'linux' ? hwndBuffer.readUInt32LE(0) : hwndBuffer;
     dragAddon.startDrag(windowId);
   });
 });


### PR DESCRIPTION
- Bump version from 2.0.1 to 2.0.2 and update description to include macOS support.
- Modify package.json to include macOS specific files in the build.
- Refactor test/main.js to load the drag addon via package entry for better platform handling.
- Implement drag functionality for Linux, macOS, and Windows in respective source files.
- Add drag.h header for common drag functionality across platforms.
- Create platform-specific implementations for drag handling in drag_linux.cc, drag_mac.mm, and drag_win.cc.